### PR TITLE
New feature: tail-call recursion -- loop P2SH-style if stack is not clean

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -70,7 +70,8 @@ static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY
                                                          SCRIPT_VERIFY_WITNESS |
                                                          SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM |
                                                          SCRIPT_VERIFY_WITNESS_PUBKEYTYPE |
-                                                         SCRIPT_VERIFY_INCREASE_CONFIRMATIONS_REQUIRED;
+                                                         SCRIPT_VERIFY_INCREASE_CONFIRMATIONS_REQUIRED |
+                                                         SCRIPT_VERIFY_TAIL_CALL;
 
 /** For convenience, standard but not mandatory verify flags. */
 static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -294,7 +294,7 @@ bool static WithdrawProofReadStackItem(const vector<valtype>& stack, const bool 
     return true;
 }
 
-bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror)
+bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& scriptIn, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror)
 {
     static const CScriptNum bnZero(0);
     static const CScriptNum bnOne(1);
@@ -304,6 +304,8 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
     static const valtype vchZero(0);
     static const valtype vchTrue(1, 1);
 
+    CScript script = scriptIn;
+tailcall:
     CScript::const_iterator pc = script.begin();
     CScript::const_iterator pend = script.end();
     CScript::const_iterator pbegincodehash = script.begin();
@@ -1682,6 +1684,15 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
     if (!vfExec.empty())
         return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
 
+    bool fAllowTailCall = (flags & SCRIPT_VERIFY_TAIL_CALL) != 0;
+    if (fAllowTailCall && (stack.size() >= 2))
+    {
+        const valtype& pubKeySerialized = stacktop(-1);
+        script = CScript(pubKeySerialized.begin(), pubKeySerialized.end());
+        popstack(stack);
+        goto tailcall;
+    }
+
     return set_success(serror);
 }
 
@@ -2117,6 +2128,8 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         witness = &emptyWitness;
     }
     bool hadWitness = false;
+    int witnessversion;
+    std::vector<unsigned char> witnessprogram;
 
     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
 
@@ -2136,13 +2149,15 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
             flags &= ~SCRIPT_VERIFY_WITHDRAW;
     }
 
+    hadWitness = scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram);
+
     vector<vector<unsigned char> > stack, stackCopy;
-    if (!EvalScript(stack, scriptSig, flags, checker, SIGVERSION_BASE, serror))
+    if (!EvalScript(stack, scriptSig, (flags & ~SCRIPT_VERIFY_TAIL_CALL), checker, SIGVERSION_BASE, serror))
         // serror is set
         return false;
     if (flags & SCRIPT_VERIFY_P2SH)
         stackCopy = stack;
-    if (!EvalScript(stack, scriptPubKey, flags, checker, SIGVERSION_BASE, serror))
+    if (!EvalScript(stack, scriptPubKey, (scriptPubKey.IsPayToScriptHash() || hadWitness) ? (flags & ~SCRIPT_VERIFY_TAIL_CALL) : flags, checker, SIGVERSION_BASE, serror))
         // serror is set
         return false;
     if (stack.empty())
@@ -2151,11 +2166,8 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         return set_error(serror, SCRIPT_ERR_EVAL_FALSE);
 
     // Bare witness programs
-    int witnessversion;
-    std::vector<unsigned char> witnessprogram;
     if (flags & SCRIPT_VERIFY_WITNESS) {
-        if (scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
-            hadWitness = true;
+        if (hadWitness) {
             if (scriptSig.size() != 0) {
                 // The scriptSig must be _exactly_ CScript(), otherwise we reintroduce malleability.
                 return set_error(serror, SCRIPT_ERR_WITNESS_MALLEATED);
@@ -2188,7 +2200,9 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         CScript pubKey2(pubKeySerialized.begin(), pubKeySerialized.end());
         popstack(stack);
 
-        if (!EvalScript(stack, pubKey2, flags, checker, SIGVERSION_BASE, serror))
+        hadWitness = pubKey2.IsWitnessProgram(witnessversion, witnessprogram);
+
+        if (!EvalScript(stack, pubKey2, hadWitness ? (flags & ~SCRIPT_VERIFY_TAIL_CALL) : flags, checker, SIGVERSION_BASE, serror))
             // serror is set
             return false;
         if (stack.empty())
@@ -2198,8 +2212,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
 
         // P2SH witness program
         if (flags & SCRIPT_VERIFY_WITNESS) {
-            if (pubKey2.IsWitnessProgram(witnessversion, witnessprogram)) {
-                hadWitness = true;
+            if (hadWitness) {
                 if (scriptSig != CScript() << std::vector<unsigned char>(pubKey2.begin(), pubKey2.end())) {
                     // The scriptSig must be _exactly_ a single push of the redeemScript. Otherwise we
                     // reintroduce malleability.

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -114,7 +114,10 @@ enum
 
     // Dirty hack to require a higher bar of bitcoin block confirmation in mempool
     //
-    SCRIPT_VERIFY_INCREASE_CONFIRMATIONS_REQUIRED = (1U << 17)
+    SCRIPT_VERIFY_INCREASE_CONFIRMATIONS_REQUIRED = (1U << 17),
+
+    // Tail call recursion
+    SCRIPT_VERIFY_TAIL_CALL = (1U << 18),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -36,11 +36,13 @@ extern unsigned nMaxDatacarrierBytes;
  * them to be valid. (but old blocks may not comply with) Currently just P2SH,
  * but in the future other flags may be added, such as a soft-fork to enforce
  * strict DER encoding.
+ *
+ * On elements, tail call evaluation is manditory as well.
  * 
  * Failing one of these tests may trigger a DoS ban - see CheckInputs() for
  * details.
  */
-static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY | SCRIPT_VERIFY_WITHDRAW;
+static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY | SCRIPT_VERIFY_WITHDRAW | SCRIPT_VERIFY_TAIL_CALL;
 
 enum txnouttype
 {

--- a/src/test/data/script_tests.json
+++ b/src/test/data/script_tests.json
@@ -2718,5 +2718,8 @@
 ["0x420102ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb2e7d2c03a9507ae265ecf5b5356885a53393a2029d241394997265a1a25aefc6 0x203e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d", "0x2020bff50d50cd12bd3d3b0f65f9bdf16b11ba98dbb6bac4e74df97f83e077c537 CHECKMERKLEBRANCHVERIFY 1", "P2SH,STRICTENC", "OK", "Check middle branch of sha256('a') || sha256('b') || sha256('c')"],
 ["0x2201019ef775d9130e8d1aa3af2abeabb23f34e2dfaf6a938d462641503f2b0bcdf98c 0x202e7d2c03a9507ae265ecf5b5356885a53393a2029d241394997265a1a25aefc6", "0x2020bff50d50cd12bd3d3b0f65f9bdf16b11ba98dbb6bac4e74df97f83e077c537 CHECKMERKLEBRANCHVERIFY 1", "P2SH,STRICTENC", "OK", "Check right branch of sha256('a') || sha256('b') || sha256('c')"],
 
+["Tail call recursion tests"],
+["0x016a", "1 0x016a", "TAIL_CALL", "OP_RETURN", "comment"],
+
 ["The End"]
 ]

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -54,7 +54,8 @@ static std::map<std::string, unsigned int> mapFlagNames = boost::assign::map_lis
     (std::string("CHECKSEQUENCEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKSEQUENCEVERIFY)
     (std::string("WITNESS"), (unsigned int)SCRIPT_VERIFY_WITNESS)
     (std::string("DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM)
-    (std::string("WITNESS_PUBKEYTYPE"), (unsigned int)SCRIPT_VERIFY_WITNESS_PUBKEYTYPE);
+    (std::string("WITNESS_PUBKEYTYPE"), (unsigned int)SCRIPT_VERIFY_WITNESS_PUBKEYTYPE)
+    (std::string("TAIL_CALL"), (unsigned int)SCRIPT_VERIFY_TAIL_CALL);
 
 unsigned int ParseScriptFlags(std::string strFlags)
 {


### PR DESCRIPTION
This PR implements tail-call recursion for fully expressive scripting capabilities. If, at the end of script execution, the stack has more than one item on it, the top-most element is interpreted as a serialized script and executed, with the remaining elements on the stack as inputs. No state is maintained, but that stack itself can be used to carry state to create other more complex recursion primitives.