### PR TITLE
Merklebranch RPC

### DIFF
--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -121,7 +121,7 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot
         // If we reach this point, h is an inner value that is not the top.
         // We combine it with itself (Bitcoin's special rule for odd levels in
         // the tree) to produce a higher level one.
-        if (pbranch && matchh) {
+        if (fMutable && pbranch && matchh) {
             pbranch->push_back(h);
         }
         if (fMutable) {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -142,6 +142,10 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getmempoolancestors", 1, "verbose" },
     { "getmempooldescendants", 1, "verbose" },
     { "bumpfee", 1, "options" },
+    { "merklebranch", 0, "leaves" },
+    { "merklebranch", 1, "position" },
+    { "merklebranch", 2, "precomputed" },
+    { "merklebranch", 3, "fast" },
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },


### PR DESCRIPTION
Adds the `merklebranch` RPC.

For demonstrations of CHECKMERKLEBRANCH opcode. See include help text for the RPC.

Also fixes yet another bug found in the Merkle branch code.